### PR TITLE
set DEFAULT_FROM_EMAIL, so password reset mails have the correct 'fro…

### DIFF
--- a/serd/settings.py
+++ b/serd/settings.py
@@ -148,5 +148,6 @@ EMAIL_HOST_USER = config['mail'].get('smtp-user')
 EMAIL_HOST_PASSWORD= config['mail'].get('smtp-pass')
 EMAIL_HOST = config['mail'].get('smtp-host')
 EMAIL_USE_SSL= True
+DEFAULT_FROM_EMAIL = EMAIL_HOST_USER
 # don't use get to force exception on empty key
 SECRET_KEY = config['key']['key']


### PR DESCRIPTION
…m' field set